### PR TITLE
improve speed

### DIFF
--- a/examples/Tutorial3_DataGeneration_CalculateObservables/quantum_ising_chain.py
+++ b/examples/Tutorial3_DataGeneration_CalculateObservables/quantum_ising_chain.py
@@ -55,7 +55,7 @@ class TFIMChainEnergy(Observable):
         :type samples: torch.Tensor
         """
         samples = to_pm1(samples)
-        log_psis = -nn_state.rbm_am.effective_energy(to_01(samples)).div(2.)
+        log_psis = -nn_state.rbm_am.effective_energy(to_01(samples)).div(2.0)
 
         shape = log_psis.shape + (samples.shape[-1],)
         log_flipped_psis = torch.zeros(
@@ -66,7 +66,7 @@ class TFIMChainEnergy(Observable):
             self._flip_spin(i, samples)  # flip the spin at site i
             log_flipped_psis[:, i] = -nn_state.rbm_am.effective_energy(
                 to_01(samples)
-            ).div(2.)
+            ).div(2.0)
             self._flip_spin(i, samples)  # flip it back
 
         log_flipped_psis = torch.logsumexp(log_flipped_psis, 1, keepdim=True).squeeze()
@@ -77,7 +77,7 @@ class TFIMChainEnergy(Observable):
         # convert to ratio of probabilities
         transverse_field_terms = log_flipped_psis.sub(log_psis).exp()
 
-        energy = transverse_field_terms.mul(self.h).add(interaction_terms).mul(-1.)
+        energy = transverse_field_terms.mul(self.h).add(interaction_terms).mul(-1.0)
 
         return energy.div(samples.shape[-1])
 

--- a/examples/Tutorial4_MonitoringObservables/quantum_ising_chain.py
+++ b/examples/Tutorial4_MonitoringObservables/quantum_ising_chain.py
@@ -55,7 +55,7 @@ class TFIMChainEnergy(Observable):
         :type samples: torch.Tensor
         """
         samples = to_pm1(samples)
-        log_psis = -nn_state.rbm_am.effective_energy(to_01(samples)).div(2.)
+        log_psis = -nn_state.rbm_am.effective_energy(to_01(samples)).div(2.0)
 
         shape = log_psis.shape + (samples.shape[-1],)
         log_flipped_psis = torch.zeros(
@@ -66,7 +66,7 @@ class TFIMChainEnergy(Observable):
             self._flip_spin(i, samples)  # flip the spin at site i
             log_flipped_psis[:, i] = -nn_state.rbm_am.effective_energy(
                 to_01(samples)
-            ).div(2.)
+            ).div(2.0)
             self._flip_spin(i, samples)  # flip it back
 
         log_flipped_psis = torch.logsumexp(log_flipped_psis, 1, keepdim=True).squeeze()
@@ -77,7 +77,7 @@ class TFIMChainEnergy(Observable):
         # convert to ratio of probabilities
         transverse_field_terms = log_flipped_psis.sub(log_psis).exp()
 
-        energy = transverse_field_terms.mul(self.h).add(interaction_terms).mul(-1.)
+        energy = transverse_field_terms.mul(self.h).add(interaction_terms).mul(-1.0)
 
         return energy.div(samples.shape[-1])
 

--- a/qucumber/callbacks/liveplotting.py
+++ b/qucumber/callbacks/liveplotting.py
@@ -70,7 +70,7 @@ class LivePlotting(CallbackBase):
             self.ax.set_xlim(0, self.total_epochs)
 
         self.ax.grid()
-        self.ax.xaxis.set_major_locator(ticker.MultipleLocator(min(self.period, 5.)))
+        self.ax.xaxis.set_major_locator(ticker.MultipleLocator(min(self.period, 5.0)))
         self.fig.show()
         self.fig.canvas.draw()
 
@@ -112,9 +112,9 @@ class LivePlotting(CallbackBase):
                 )
 
             y_avg = np.max(np.abs(past_values))
-            y_log_avg = np.log10(y_avg) if y_avg != 0 else -1.
+            y_log_avg = np.log10(y_avg) if y_avg != 0 else -1.0
             y_tick_exp = int(np.sign(y_log_avg) * np.ceil(np.abs(y_log_avg)))
-            y_tick_interval = (10 ** y_tick_exp) / 2.
+            y_tick_interval = (10 ** y_tick_exp) / 2.0
             self.ax.yaxis.set_major_locator(ticker.MultipleLocator(y_tick_interval))
 
             self.ax.set_xlabel("Epochs")

--- a/qucumber/nn_states/complex_wavefunction.py
+++ b/qucumber/nn_states/complex_wavefunction.py
@@ -171,7 +171,7 @@ class ComplexWaveFunction(WaveFunctionBase):
         Upsi_v = torch.zeros_like(Upsi, device=self.device)
         Z = torch.zeros(grad_size, dtype=torch.double, device=self.device)
         Z2 = torch.zeros((2, grad_size), dtype=torch.double, device=self.device)
-        U = torch.tensor([1., 1.], dtype=torch.double, device=self.device)
+        U = torch.tensor([1.0, 1.0], dtype=torch.double, device=self.device)
         Ut = np.zeros_like(Us[:, 0], dtype=complex)
         ints_size = np.arange(sites.size)
 

--- a/qucumber/observables/observable.py
+++ b/qucumber/observables/observable.py
@@ -222,7 +222,7 @@ class SumObservable(ObservableBase):
             self.name = name
 
     def apply(self, samples, rbm):
-        result = 0.
+        result = 0.0
         if isinstance(self.left, (float, int)):
             result += self.left
         if isinstance(self.right, (float, int)):

--- a/qucumber/observables/utils.py
+++ b/qucumber/observables/utils.py
@@ -25,7 +25,7 @@ def to_pm1(samples):
                     Must be using the :math:`\sigma_i = 0, 1` convention.
     :type samples: torch.Tensor
     """
-    return samples.mul(2.).sub(1.)
+    return samples.mul(2.0).sub(1.0)
 
 
 def to_01(samples):
@@ -35,7 +35,7 @@ def to_01(samples):
                     Must be using the :math:`\sigma_i = -1, +1` convention.
     :type samples: torch.Tensor
     """
-    return samples.add(1.).div(2.)
+    return samples.add(1.0).div(2.0)
 
 
 def update_statistics(avg_a, var_a, len_a, avg_b, var_b, len_b):

--- a/qucumber/rbm/binary_rbm.py
+++ b/qucumber/rbm/binary_rbm.py
@@ -117,7 +117,7 @@ class BinaryRBM(nn.Module):
             vb_grad = -v
             hb_grad = -prob
         else:
-            W_grad = -torch.einsum("ij,ik->jk", (prob, v))
+            W_grad = -torch.matmul(prob.t(), v)
             vb_grad = -torch.einsum("ij->j", (v,))
             hb_grad = -torch.einsum("ij->j", (prob,))
 

--- a/qucumber/rbm/binary_rbm.py
+++ b/qucumber/rbm/binary_rbm.py
@@ -118,8 +118,8 @@ class BinaryRBM(nn.Module):
             hb_grad = -prob
         else:
             W_grad = -torch.matmul(prob.t(), v)
-            vb_grad = -torch.einsum("ij->j", (v,))
-            hb_grad = -torch.einsum("ij->j", (prob,))
+            vb_grad = -torch.sum(v, 0)
+            hb_grad = -torch.sum(prob, 0)
 
         return parameters_to_vector([W_grad, vb_grad, hb_grad])
 

--- a/qucumber/utils/training_statistics.py
+++ b/qucumber/utils/training_statistics.py
@@ -40,7 +40,7 @@ def fidelity(nn_state, target_psi, space, **kwargs):
     :rtype: torch.Tensor
     """
     Z = nn_state.compute_normalization(space)
-    F = torch.tensor([0., 0.], dtype=torch.double, device=nn_state.device)
+    F = torch.tensor([0.0, 0.0], dtype=torch.double, device=nn_state.device)
     target_psi = target_psi.to(nn_state.device)
     for i in range(len(space)):
         psi = nn_state.psi(space[i]) / Z.sqrt()
@@ -90,7 +90,7 @@ def rotate_psi(nn_state, basis, space, unitaries, psi=None):
                     cnt += 1
                 else:
                     v[j] = space[x, j]
-            U = torch.tensor([1., 0.], dtype=torch.double, device=nn_state.device)
+            U = torch.tensor([1.0, 0.0], dtype=torch.double, device=nn_state.device)
             for ii in range(num_nontrivial_U):
                 tmp = unitaries[basis[nontrivial_sites[ii]]]
                 tmp = tmp[
@@ -137,7 +137,8 @@ def KL(nn_state, target_psi, space, bases=None, **kwargs):
         num_bases = 1
         for i in range(len(space)):
             KL += (
-                cplx.norm_sqr(target_psi[:, i]) * (cplx.norm_sqr(target_psi[:, i]) + eps).log()
+                cplx.norm_sqr(target_psi[:, i])
+                * (cplx.norm_sqr(target_psi[:, i]) + eps).log()
             )
             KL -= (
                 cplx.norm_sqr(target_psi[:, i])

--- a/qucumber/utils/unitaries.py
+++ b/qucumber/utils/unitaries.py
@@ -36,15 +36,15 @@ def create_dict(**kwargs):
     """
     dictionary = {
         "X": torch.tensor(
-            [[[1., 1.], [1., -1.]], [[0., 0.], [0., 0.]]], dtype=torch.double
+            [[[1.0, 1.0], [1.0, -1.0]], [[0.0, 0.0], [0.0, 0.0]]], dtype=torch.double
         )
         / np.sqrt(2),
         "Y": torch.tensor(
-            [[[1., 0.], [1., 0.]], [[0., -1.], [0., 1.]]], dtype=torch.double
+            [[[1.0, 0.0], [1.0, 0.0]], [[0.0, -1.0], [0.0, 1.0]]], dtype=torch.double
         )
         / np.sqrt(2),
         "Z": torch.tensor(
-            [[[1., 0.], [0., 1.]], [[0., 0.], [0., 0.]]], dtype=torch.double
+            [[[1.0, 0.0], [0.0, 1.0]], [[0.0, 0.0], [0.0, 0.0]]], dtype=torch.double
         ),
     }
 

--- a/tests/grads_utils.py
+++ b/tests/grads_utils.py
@@ -165,7 +165,7 @@ class ComplexGradsUtils:
                         v[j] = vis[x, j]
 
                 U = torch.tensor(
-                    [1., 0.], dtype=torch.double, device=self.nn_state.device
+                    [1.0, 0.0], dtype=torch.double, device=self.nn_state.device
                 )
                 for ii in range(num_nontrivial_U):
                     tmp = unitary_dict[basis[nontrivial_sites[ii]]]

--- a/tests/test_grads.py
+++ b/tests/test_grads.py
@@ -33,14 +33,14 @@ from . import __tests_location__
 
 K = 10
 SEED = 1234
-EPS = 1.e-6
+EPS = 1.0e-6
 
 TOL = torch.tensor(2e-9, dtype=torch.double)
 PDIFF = torch.tensor(100, dtype=torch.double)  # NLL grad tests are a bit too random tbh
 
 
 def percent_diff(a, b):  # for NLL
-    numerator = torch.abs(a - b) * 100.
+    numerator = torch.abs(a - b) * 100.0
     denominator = torch.abs(0.5 * (a + b))
     return numerator / denominator
 


### PR DESCRIPTION
This will close #57 

Case 1:

original is 2x slower

```python
In [1]: import torch

In [2]: p = torch.rand(80, 100, dtype=torch.float64)

In [3]: v = torch.rand(80, 40, dtype=torch.float64)

In [4]: torch.equal(torch.einsum('ij,ik->jk', (p, v)), torch.matmul(p.t(), v))
Out[4]: True

In [5]: %timeit torch.einsum('ij,ik->jk', (p, v))
59.1 µs ± 1.47 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [6]: %timeit torch.matmul(p.t(), v)
26.8 µs ± 960 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Case 2:

original is 4x slower

```python
In [7]: torch.equal(torch.einsum('ij->j', (v, )), torch.sum(v, 0))
Out[7]: True

In [9]: %timeit torch.einsum('ij->j', (v, ))
14.9 µs ± 560 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [10]: %timeit torch.sum(v, 0)
3.61 µs ± 113 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
