### PR TITLE
[WIP] Transition to PyTorch's complex API

### DIFF
--- a/qucumber/nn_states/density_matrix.py
+++ b/qucumber/nn_states/density_matrix.py
@@ -203,7 +203,7 @@ class DensityMatrix(NeuralStateBase):
 
         if phase:
             temp = (v.unsqueeze(1) - vp.unsqueeze(0)) if expand else (v - vp)
-            sig = cplx.scalar_mult(sig, cplx.I)
+            sig = 1j * sig
 
             ab_grad_real = torch.zeros_like(self.rbm_ph.aux_bias).expand(
                 *batch_sizes, -1
@@ -215,7 +215,7 @@ class DensityMatrix(NeuralStateBase):
             ab_grad_real = cplx.real(sig)
             ab_grad_imag = cplx.imag(sig)
 
-        U_grad = 0.5 * torch.einsum("c...j,...k->c...jk", sig, temp)
+        U_grad = 0.5 * torch.einsum("...j,...k->...jk", sig, temp)
         U_grad_real = cplx.real(U_grad)
         U_grad_imag = cplx.imag(U_grad)
 

--- a/qucumber/nn_states/positive_wavefunction.py
+++ b/qucumber/nn_states/positive_wavefunction.py
@@ -120,7 +120,6 @@ class PositiveWaveFunction(WaveFunctionBase):
                   each visible state
         :rtype: torch.Tensor
         """
-        # vector/tensor of shape (2, len(v))
         return cplx.make_complex(self.amplitude(v))
 
     def gradient(self, v, *args, **kwargs):

--- a/qucumber/utils/cplx.py
+++ b/qucumber/utils/cplx.py
@@ -36,14 +36,13 @@ def make_complex(x, y=None):
     :rtype: torch.Tensor
     """
     if isinstance(x, np.ndarray):
-        return torch.tensor(x)
-        # return make_complex(torch.tensor(x.real), torch.tensor(x.imag)).contiguous()
+        x = torch.tensor(x)
 
     if y is None:
         y = torch.zeros_like(x)
-    else:
+    elif isinstance(y, np.ndarray):
         y = torch.tensor(y)
-    return torch.tensor(x) + 1j * y
+    return x + 1j * y
 
 
 def numpy(x):

--- a/qucumber/utils/data.py
+++ b/qucumber/utils/data.py
@@ -42,9 +42,10 @@ def load_data(tr_samples_path, tr_psi_path=None, tr_bases_path=None, bases_path=
 
     if tr_psi_path is not None:
         target_psi_data = np.loadtxt(tr_psi_path, dtype="float32")
-        target_psi = torch.zeros(2, len(target_psi_data), dtype=torch.double)
-        target_psi[0] = torch.tensor(target_psi_data[:, 0], dtype=torch.double)
-        target_psi[1] = torch.tensor(target_psi_data[:, 1], dtype=torch.double)
+        target_psi = cplx.make_complex(
+            torch.tensor(target_psi_data[:, 0], dtype=torch.double),
+            torch.tensor(target_psi_data[:, 1], dtype=torch.double),
+        )
         data.append(target_psi)
 
     if tr_bases_path is not None:

--- a/qucumber/utils/training_statistics.py
+++ b/qucumber/utils/training_statistics.py
@@ -179,8 +179,7 @@ def KL(nn_state, target, space=None, bases=None, **kwargs):
     if bases is None:
         target_probs = cplx.absolute_value(target) ** 2
         nn_probs = nn_state.probability(space, Z)
-
-        KL += _single_basis_KL(target_probs, nn_probs)
+        return _single_basis_KL(target_probs, nn_probs)
 
     elif isinstance(nn_state, WaveFunctionBase):
         for basis in bases:

--- a/qucumber/utils/training_statistics.py
+++ b/qucumber/utils/training_statistics.py
@@ -52,13 +52,13 @@ def fidelity(nn_state, target, space=None, **kwargs):
     target = target.to(nn_state.device)
 
     if isinstance(nn_state, WaveFunctionBase):
-        assert target.dim() == 2, "target must be a complex vector!"
+        assert target.dim() == 1, "target must be a complex vector!"
 
         psi = nn_state.psi(space) / Z.sqrt()
         F = cplx.inner_prod(target, psi)
         return cplx.absolute_value(F).pow_(2).item()
     else:
-        assert target.dim() == 3, "target must be a complex matrix!"
+        assert target.dim() == 2, "target must be a complex matrix!"
 
         rho = nn_state.rho(space, space) / Z
         rho_rbm_ = cplx.numpy(rho)
@@ -168,9 +168,9 @@ def KL(nn_state, target, space=None, bases=None, **kwargs):
         if bases is None:
             bases = list(target.keys())
         else:
-            assert set(bases) == set(
+            assert set(bases) <= set(
                 target.keys()
-            ), "Given bases must match the keys of the target_psi dictionary."
+            ), "Given bases must be a subset of the keys of the target_psi dictionary."
     else:
         target = target.to(nn_state.device)
 
@@ -186,9 +186,9 @@ def KL(nn_state, target, space=None, bases=None, **kwargs):
         for basis in bases:
             if isinstance(target, dict):
                 target_psi_r = target[basis]
-                assert target_psi_r.dim() == 2, "target must be a complex vector!"
+                assert target_psi_r.dim() == 1, "target must be a complex vector!"
             else:
-                assert target.dim() == 2, "target must be a complex vector!"
+                assert target.dim() == 1, "target must be a complex vector!"
                 target_psi_r = rotate_psi(nn_state, basis, space, psi=target)
 
             psi_r = rotate_psi(nn_state, basis, space)
@@ -202,10 +202,10 @@ def KL(nn_state, target, space=None, bases=None, **kwargs):
         for basis in bases:
             if isinstance(target, dict):
                 target_rho_r = target[basis]
-                assert target_rho_r.dim() == 3, "target must be a complex matrix!"
+                assert target_rho_r.dim() == 2, "target must be a complex matrix!"
                 target_probs_r = torch.diagonal(cplx.real(target_rho_r))
             else:
-                assert target.dim() == 3, "target must be a complex matrix!"
+                assert target.dim() == 2, "target must be a complex matrix!"
                 target_probs_r = rotate_rho_probs(nn_state, basis, space, rho=target)
 
             rho_r = rotate_rho_probs(nn_state, basis, space)

--- a/qucumber/utils/unitaries.py
+++ b/qucumber/utils/unitaries.py
@@ -175,7 +175,7 @@ def _rotate_basis_state(nn_state, basis, states, unitaries=None):
 
         Ut = torch.prod(all_Us.cpu(), dim=-1).to(
             all_Us
-        )  # FIXME: prod is currently unsupported on GPU
+        )  # FIXME: prod for torch.complex is currently unsupported on GPU
     else:
         v = states.unsqueeze(0)
         Ut = torch.ones(v.shape[:-1], dtype=torch.cdouble, device=nn_state.device)

--- a/tests/grads_utils.py
+++ b/tests/grads_utils.py
@@ -39,7 +39,7 @@ class PosGradsUtils:
         )
         for i in range(len(space)):
             sample_grad = self.nn_state.gradient(space[i])[0]
-            grad_KL += ((target[0, i]) ** 2) * sample_grad
+            grad_KL += (cplx.absolute_value(target[i]) ** 2) * sample_grad
             grad_KL -= self.nn_state.probability(space[i], Z) * sample_grad
         return [grad_KL]
 
@@ -86,17 +86,16 @@ class PosGradsUtils:
 class ComplexGradsUtils(PosGradsUtils):
     def load_target_psi(self, bases, psi_data):
         if isinstance(psi_data, torch.Tensor):
-            psi_data = psi_data.clone().detach().to(dtype=torch.double)
+            psi_data = psi_data.clone().detach().to(dtype=torch.cdouble)
         else:
-            psi_data = torch.tensor(psi_data, dtype=torch.double)
+            psi_data = torch.tensor(psi_data, dtype=torch.cdouble)
 
         psi_dict = {}
-        D = int(psi_data.shape[1] / float(len(bases)))
+        D = int(psi_data.shape[0] / float(len(bases)))
 
         for b in range(len(bases)):
-            psi = torch.zeros(2, D, dtype=torch.double)
-            psi[0, ...] = psi_data[0, b * D : (b + 1) * D]
-            psi[1, ...] = psi_data[1, b * D : (b + 1) * D]
+            psi = torch.zeros(D, dtype=torch.cdouble)
+            psi = psi_data[b * D : (b + 1) * D]
             psi_dict[bases[b]] = psi
 
         return psi_dict

--- a/tests/grads_utils.py
+++ b/tests/grads_utils.py
@@ -165,7 +165,7 @@ class DensityGradsUtils(ComplexGradsUtils):
             else:
                 target_r = rotate_rho_probs(
                     self.nn_state, all_bases[b], space, rho=target
-                )
+                ).to(dtype=torch.double)
 
             for i in range(len(space)):
                 rotated_grad = self.nn_state.gradient(space[i], all_bases[b])

--- a/tests/test_cplx.py
+++ b/tests/test_cplx.py
@@ -33,7 +33,7 @@ class TestCplx(unittest.TestCase):
         y = torch.tensor([5, 6, 7, 8])
         z = cplx.make_complex(x, y)
 
-        expect = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        expect = torch.tensor([1 + 5j, 2 + 6j, 3 + 7j, 4 + 8j])
 
         self.assertTensorsEqual(expect, z, msg="Make Complex Vector failed!")
 
@@ -41,7 +41,7 @@ class TestCplx(unittest.TestCase):
         x = torch.tensor([1, 2, 3, 4])
         z = cplx.make_complex(x)
 
-        expect = torch.tensor([[1, 2, 3, 4], [0, 0, 0, 0]])
+        expect = torch.tensor([1 + 0j, 2 + 0j, 3 + 0j, 4 + 0j])
 
         self.assertTensorsEqual(
             expect, z, msg="Making a complex vector with zero imaginary part failed!"
@@ -52,7 +52,7 @@ class TestCplx(unittest.TestCase):
         y = torch.tensor([[5, 6], [7, 8]])
         z = cplx.make_complex(x, y)
 
-        expect = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+        expect = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
 
         self.assertTensorsEqual(expect, z, msg="Make Complex Matrix failed!")
 
@@ -61,28 +61,36 @@ class TestCplx(unittest.TestCase):
         y = torch.tensor([5, 6])
         z = cplx.make_complex(x, y)
 
-        self.assertTensorsEqual(x, cplx.real(z), msg="Real part of vector failed!")
+        self.assertTensorsEqual(
+            x, cplx.real(z).to(x), msg="Real part of vector failed!"
+        )
 
     def test_imag_part_of_vector(self):
         x = torch.tensor([1, 2])
         y = torch.tensor([5, 6])
         z = cplx.make_complex(x, y)
 
-        self.assertTensorsEqual(y, cplx.imag(z), msg="Imaginary part of vector failed!")
+        self.assertTensorsEqual(
+            y, cplx.imag(z).to(y), msg="Imaginary part of vector failed!"
+        )
 
     def test_real_part_of_matrix(self):
         x = torch.tensor([[1, 2], [3, 4]])
         y = torch.tensor([[5, 6], [7, 8]])
         z = cplx.make_complex(x, y)
 
-        self.assertTensorsEqual(x, cplx.real(z), msg="Real part of matrix failed!")
+        self.assertTensorsEqual(
+            x, cplx.real(z).to(x), msg="Real part of matrix failed!"
+        )
 
     def test_imag_part_of_matrix(self):
         x = torch.tensor([[1, 2], [3, 4]])
         y = torch.tensor([[5, 6], [7, 8]])
         z = cplx.make_complex(x, y)
 
-        self.assertTensorsEqual(y, cplx.imag(z), msg="Imaginary part of matrix failed!")
+        self.assertTensorsEqual(
+            y, cplx.imag(z).to(y), msg="Imaginary part of matrix failed!"
+        )
 
     def test_real_part_of_tensor(self):
         x = torch.randn(3, 3, 3)
@@ -109,10 +117,10 @@ class TestCplx(unittest.TestCase):
             return cplx.make_complex(x, y)
 
     def test_elementwise_mult(self):
-        z1 = torch.tensor([[2, 3, 5], [6, 7, 2]], dtype=torch.double)
-        z2 = torch.tensor([[1, 2, 2], [3, 4, 8]], dtype=torch.double)
+        z1 = torch.tensor([2 + 6j, 3 + 7j, 5 + 2j])
+        z2 = torch.tensor([1 + 3j, 2 + 4j, 2 + 8j])
 
-        expect = torch.tensor([[-16, -22, -6], [12, 26, 44]], dtype=torch.double)
+        expect = torch.tensor([-16 + 12j, -22 + 26j, -6 + 44j])
 
         self.assertTensorsEqual(
             cplx.elementwise_mult(z1, z2),
@@ -121,12 +129,10 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_elementwise_div(self):
-        z1 = torch.tensor([[2, 3, 5], [6, 7, 2]], dtype=torch.double)
-        z2 = torch.tensor([[1, 2, 2], [3, 4, 8]], dtype=torch.double)
+        z1 = torch.tensor([2 + 6j, 3 + 7j, 5 + 2j])
+        z2 = torch.tensor([1 + 3j, 2 + 4j, 2 + 8j])
 
-        expect = torch.tensor(
-            [[2, (17 / 10), (13 / 34)], [0, (1 / 10), (-9 / 17)]], dtype=torch.double
-        )
+        expect = torch.tensor([2 + 0j, (17 / 10) + (1j / 10), (13 / 34) + (-9j / 17)],)
 
         self.assertTensorsAlmostEqual(
             cplx.elementwise_division(z1, z2),
@@ -141,10 +147,10 @@ class TestCplx(unittest.TestCase):
             return cplx.elementwise_division(z1, z2)
 
     def test_scalar_vector_mult(self):
-        scalar = torch.tensor([2, 3], dtype=torch.double)
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
+        scalar = torch.tensor([2 + 3j])
+        vector = torch.tensor([1 + 3j, 2 + 4j])
 
-        expect = torch.tensor([[-7, -8], [9, 14]], dtype=torch.double)
+        expect = torch.tensor([-7 + 9j, -8 + 14j])
 
         self.assertTensorsEqual(
             cplx.scalar_mult(scalar, vector),
@@ -153,12 +159,10 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_scalar_matrix_mult(self):
-        scalar = torch.tensor([2, 3], dtype=torch.double)
-        matrix = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.double)
+        scalar = torch.tensor([2 + 3j])
+        matrix = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
 
-        expect = torch.tensor(
-            [[[-13, -14], [-15, -16]], [[13, 18], [23, 28]]], dtype=torch.double
-        )
+        expect = torch.tensor([[-13 + 13j, -14 + 18j], [-15 + 23j, -16 + 28j]])
 
         self.assertTensorsEqual(
             cplx.scalar_mult(scalar, matrix),
@@ -167,11 +171,12 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_scalar_mult_overwrite(self):
-        scalar = torch.tensor([2, 3], dtype=torch.double)
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
-        out = torch.zeros_like(vector)
-        expect = torch.tensor([[-7, -8], [9, 14]], dtype=torch.double)
+        scalar = torch.tensor([2 + 3j])
+        vector = torch.tensor([1 + 3j, 2 + 4j])
 
+        expect = torch.tensor([-7 + 9j, -8 + 14j])
+
+        out = torch.zeros_like(vector)
         cplx.scalar_mult(scalar, vector, out=out)
 
         self.assertTensorsEqual(
@@ -181,8 +186,8 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_scalar_mult_overwrite_fail(self):
-        scalar = torch.tensor([2, 3], dtype=torch.double)
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
+        scalar = torch.tensor([2 + 3j])
+        vector = torch.tensor([1 + 3j, 2 + 4j])
 
         with self.assertRaises(RuntimeError):
             cplx.scalar_mult(scalar, vector, out=vector)
@@ -191,10 +196,10 @@ class TestCplx(unittest.TestCase):
             cplx.scalar_mult(scalar, vector, out=scalar)
 
     def test_matrix_vector_matmul(self):
-        matrix = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.double)
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
+        matrix = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
+        vector = torch.tensor([1 + 3j, 2 + 4j])
 
-        expect = torch.tensor([[-34, -42], [28, 48]], dtype=torch.double)
+        expect = torch.tensor([-34 + 28j, -42 + 48j])
 
         self.assertTensorsEqual(
             cplx.matmul(matrix, vector),
@@ -203,11 +208,9 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_matrix_matrix_matmul(self):
-        matrix1 = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.double)
-        matrix2 = torch.tensor([[[1, 0], [3, 0]], [[0, 6], [0, 8]]], dtype=torch.double)
-        expect = torch.tensor(
-            [[[7, -78], [15, -106]], [[23, 22], [31, 50]]], dtype=torch.double
-        )
+        matrix1 = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
+        matrix2 = torch.tensor([[1 + 0j, 0 + 6j], [3 + 0j, 0 + 8j]])
+        expect = torch.tensor([[7 + 23j, -78 + 22j], [15 + 31j, -106 + 50j]])
         self.assertTensorsEqual(
             cplx.matmul(matrix1, matrix2),
             expect,
@@ -215,77 +218,64 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_scalar_inner_prod(self):
-        scalar = torch.tensor([1, 2], dtype=torch.double)
-        expect = torch.tensor([5, 0], dtype=torch.double)
+        scalar = torch.tensor(1 + 2j)
+        expect = torch.tensor(5 + 0j)
         self.assertTensorsEqual(
             cplx.inner_prod(scalar, scalar), expect, msg="Scalar inner product failed!"
         )
 
     def test_vector_inner_prod(self):
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
-        expect = torch.tensor([30, 0], dtype=torch.double)
+        vector = torch.tensor([1 + 3j, 2 + 4j])
+        expect = torch.tensor(30 + 0j)
         self.assertTensorsEqual(
             cplx.inner_prod(vector, vector), expect, msg="Vector inner product failed!"
         )
 
     def test_outer_prod(self):
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
-        expect = torch.tensor(
-            [[[10, 14], [14, 20]], [[0, 2], [-2, 0]]], dtype=torch.double
-        )
+        vector = torch.tensor([1 + 3j, 2 + 4j])
+        expect = torch.tensor([[10 + 0j, 14 + 2j], [14 - 2j, 20 + 0j]])
         self.assertTensorsEqual(
             cplx.outer_prod(vector, vector), expect, msg="Outer product failed!"
         )
 
     def test_outer_prod_error_small(self):
-        # take outer prod of 2 rank 1 tensors, instead of rank 2
-        tensor = torch.tensor([1, 2], dtype=torch.double)
+        # take outer prod of 2 scalars, instead of vectors
+        scalar = torch.tensor(1 + 2j)
         with self.assertRaises(ValueError):
-            cplx.outer_prod(tensor, tensor)
+            cplx.outer_prod(scalar, scalar)
 
     def test_outer_prod_error_large(self):
-        # take outer prod of 2 rank 3 tensors, instead of rank 2
-        tensor = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.double)
+        # take outer prod of 2 matrices, instead of vectors
+        matrix = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
         with self.assertRaises(ValueError):
-            cplx.outer_prod(tensor, tensor)
+            cplx.outer_prod(matrix, matrix)
 
     def test_conjugate(self):
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
+        vector = torch.tensor([1 + 3j, 2 + 4j])
 
-        expect = torch.tensor([[1, 2], [-3, -4]], dtype=torch.double)
+        expect = torch.tensor([1 - 3j, 2 - 4j])
 
         self.assertTensorsEqual(
             cplx.conjugate(vector), expect, msg="Vector conjugate failed!"
         )
 
     def test_matrix_conjugate(self):
-        matrix = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.double)
-        expect = torch.tensor(
-            [[[1, 3], [2, 4]], [[-5, -7], [-6, -8]]], dtype=torch.double
-        )
+        matrix = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
+        expect = torch.tensor([[1 - 5j, 3 - 7j], [2 - 6j, 4 - 8j]])
         self.assertTensorsEqual(
             cplx.conjugate(matrix), expect, msg="Matrix conjugate failed!"
         )
 
     def test_kronecker_prod(self):
-        matrix = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.double)
+        matrix = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
 
         expect = torch.tensor(
             [
-                [
-                    [-24, -28, -28, -32],
-                    [-32, -36, -36, -40],
-                    [-32, -36, -36, -40],
-                    [-40, -44, -44, -48],
-                ],
-                [
-                    [10, 16, 16, 24],
-                    [22, 28, 32, 40],
-                    [22, 32, 28, 40],
-                    [42, 52, 52, 64],
-                ],
+                [-24 + 10j, -28 + 16j, -28 + 16j, -32 + 24j],
+                [-32 + 22j, -36 + 28j, -36 + 32j, -40 + 40j],
+                [-32 + 22j, -36 + 32j, -36 + 28j, -40 + 40j],
+                [-40 + 42j, -44 + 52j, -44 + 52j, -48 + 64j],
             ],
-            dtype=torch.double,
         )
 
         self.assertTensorsEqual(
@@ -294,7 +284,7 @@ class TestCplx(unittest.TestCase):
 
     def test_kronecker_prod_error_small(self):
         # take KronProd of 2 rank 2 tensors, instead of rank 3
-        tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
+        tensor = torch.tensor([1 + 3j, 2 + 4j])
         with self.assertRaises(ValueError):
             cplx.kronecker_prod(tensor, tensor)
 
@@ -305,9 +295,9 @@ class TestCplx(unittest.TestCase):
             cplx.kronecker_prod(tensor, tensor)
 
     def test_vector_scalar_divide(self):
-        scalar = torch.tensor([1, 2], dtype=torch.double)
-        vector = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
-        expect = torch.tensor([[1.4, 2.0], [0.2, 0.0]], dtype=torch.double)
+        scalar = torch.tensor(1 + 2j)
+        vector = torch.tensor([1 + 3j, 2 + 4j])
+        expect = torch.tensor([1.4 + 0.2j, 2.0 + 0.0j])
 
         self.assertTensorsAlmostEqual(
             cplx.scalar_divide(vector, scalar),
@@ -316,12 +306,10 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_matrix_scalar_divide(self):
-        scalar = torch.tensor([1, 2], dtype=torch.double)
-        matrix = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.double)
+        scalar = torch.tensor(1 + 2j)
+        matrix = torch.tensor([[1 + 5j, 2 + 6j], [3 + 7j, 4 + 8j]])
 
-        expect = torch.tensor(
-            [[[2.2, 2.8], [3.4, 4.0]], [[0.6, 0.4], [0.2, 0.0]]], dtype=torch.double
-        )
+        expect = torch.tensor([[2.2 + 0.6j, 2.8 + 0.4j], [3.4 + 0.2j, 4.0 + 0.0j]])
 
         self.assertTensorsAlmostEqual(
             cplx.scalar_divide(matrix, scalar),
@@ -330,26 +318,27 @@ class TestCplx(unittest.TestCase):
         )
 
     def test_norm_sqr(self):
-        scalar = torch.tensor([3, 4], dtype=torch.double)
-        expect = torch.tensor(25, dtype=torch.double)
+        scalar = torch.tensor(3 + 4j)
+        expect = torch.tensor(25)
 
-        self.assertTensorsEqual(cplx.norm_sqr(scalar), expect, msg="Norm failed!")
+        self.assertTensorsEqual(
+            cplx.norm_sqr(scalar).to(expect), expect, msg="Norm failed!"
+        )
 
     def test_norm(self):
-        scalar = torch.tensor([3, 4], dtype=torch.double)
-        expect = torch.tensor(5, dtype=torch.double)
+        scalar = torch.tensor(3 + 4j)
+        expect = torch.tensor(5)
 
-        self.assertTensorsEqual(cplx.norm(scalar), expect, msg="Norm failed!")
+        self.assertTensorsEqual(
+            cplx.norm(scalar).to(expect), expect, msg="Norm failed!"
+        )
 
     def test_absolute_value(self):
         tensor = torch.tensor(
-            [[[5, 5, -5, -5], [3, 6, -9, 1]], [[2, -2, 2, -2], [-7, 8, 0, 4]]],
-            dtype=torch.double,
+            [[5 + 2j, 5 - 2j, -5 + 2j, -5 - 2j], [3 - 7j, 6 + 8j, -9 + 0j, 1 + 4j]]
         )
 
-        expect = torch.tensor(
-            [[[np.sqrt(29)] * 4, [np.sqrt(58), 10, 9, np.sqrt(17)]]], dtype=torch.double
-        )
+        expect = torch.tensor([[np.sqrt(29)] * 4, [np.sqrt(58), 10, 9, np.sqrt(17)]])
 
         self.assertTensorsAlmostEqual(
             cplx.absolute_value(tensor), expect, msg="Absolute Value failed!"

--- a/tests/test_grads.py
+++ b/tests/test_grads.py
@@ -22,6 +22,7 @@ import pytest
 
 import qucumber
 from qucumber.nn_states import PositiveWaveFunction, ComplexWaveFunction, DensityMatrix
+from qucumber.utils import cplx
 
 from grads_utils import ComplexGradsUtils, PosGradsUtils, DensityGradsUtils
 from conftest import all_state_types, assertAlmostEqual, TOL
@@ -41,6 +42,8 @@ def positive_wavefunction_data(request, gpu, num_hidden):
 
     data = torch.tensor(test_data["tfim1d"]["train_samples"], dtype=torch.double)
     target = torch.tensor(test_data["tfim1d"]["target_psi"], dtype=torch.double).t()
+
+    target = cplx.make_complex(target[0])
 
     num_visible = data.shape[-1]
 
@@ -78,6 +81,8 @@ def complex_wavefunction_data(request, gpu, num_hidden):
     target_psi_tmp = torch.tensor(
         test_data["2qubits"]["target_psi"], dtype=torch.double
     ).t()
+
+    target_psi_tmp = cplx.make_complex(target_psi_tmp[0], target_psi_tmp[1])
 
     num_visible = data_samples.shape[-1]
 
@@ -137,6 +142,8 @@ def density_matrix_data(request, gpu, num_hidden):
     target = torch.tensor(
         test_data["density_matrix"]["density_matrix"], dtype=torch.double
     )
+
+    target = cplx.make_complex(target[0], target[1])
 
     num_visible = data_samples.shape[-1]
     num_aux = num_visible + 1

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     -e .[coverage]
 commands =
     torchnightly: python -m pip uninstall -y torch
-    torchnightly: python -m pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    torchnightly: python -m pip install -U --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     pytest --cov=qucumber --no-cov-on-fail {posargs}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,15 +21,14 @@ skipsdist = true
 skip_missing_interpreters = true
 envlist =
     cov-init
-    py{36, 37}-torch{10, 11, 12, 13, 14, 15, 16, nightly}
-    py38-torch{14, 15, 16, nightly}
+    py{37}-torch{nightly}
     cov-report
     misc
 
 [travis]
 os =
-    linux: py{36, 37}-torch{10, 11, 12, 13, 14, 15, 16, nightly}, py38-torch{14, 15, 16, nightly}
-    osx: py{36, 37}-torch{10, 11, 12, 13, 14, 15, 16, nightly}, py38-torch{14, 15, 16, nightly}
+    linux: py{36,37,38}-torch{nightly}
+    osx: py{36,37,38}-torch{nightly}
 
 [travis:env]
 TORCH =
@@ -73,8 +72,7 @@ commands =
 setenv = {[testenv:cov-init]setenv}
 depends =
     cov-init
-    py{36, 37}-torch{10, 11, 12, 13, 14, 15, 16, nightly}
-    py38-torch{14, 15, 16, nightly}
+    py{36,37,38}-torch{nightly}
 deps = {[testenv:cov-init]deps}
 commands =
     coverage combine


### PR DESCRIPTION
This won't be merged for a while since PyTorch's complex API isn't stable yet

TODO:
- [ ] Fix KL bug
   - KL divergence seems like it's being computed wrong for the complex cases (DensityMatrix's numerical and algorithmic gradients seem to both be wrong)
   - [ ] Add gradient tests which only operate in the reference basis (i.e. dont need to do any grad rotations)
   - [ ] In gradient tests, if the gradients for one sub-network are wrong, the other sub-networks aren't tested. Should fix this to test all sub-networks before erroring out (maybe separate tests for each sub-network?)